### PR TITLE
`./build` allows building and running tests via  a single command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ ocaml-deps:
 	eval $$(opam config env) \
 	opam install --yes mlgmp zarith uuidm
 
+# Setting BYTE=true tells IELE to build staticly, avoiding incorrect setting
+# of rpath in IELE's build scripts.
+# We set `make deps`'s input to `/dev/null` to prevent IELE's opam
+# invocation from asking us to modify our bashrc
 iele: $(iele_submodule)/.git ocaml-deps
 	bash -c '  . bin/activate                                                \
             && cd $(iele_submodule)                                          \
@@ -49,8 +53,8 @@ iele: $(iele_submodule)/.git ocaml-deps
                                --enable-experimental                         \
                 && make                                                      \
                 && make install)                                             \
-            && make deps                                                     \
-            && make'
+            && make BYTE=yes deps </dev/null                                 \
+            && make BYTE=yes '
 
 # Build
 # -----

--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,12 @@ clean:
 # Dependencies
 # ------------
 
-dep_files:=$(k_submodule)/.git
-
-deps: $(dep_files) ocaml-deps $(k_bin)/krun iele
+deps: $(k_bin)/krun ocaml-deps iele
 
 %/.git: .git/HEAD
 	git submodule update --recursive --init -- $(dir $*)
 
-$(k_bin)/krun:
+$(k_bin)/krun: $(k_submodule)/.git
 	cd $(k_submodule) \
 		&& mvn package -q -DskipTests
 
@@ -60,7 +58,7 @@ iele: $(iele_submodule)/.git ocaml-deps
 # Allow expansion of $* in wildcard; See https://stackoverflow.com/questions/15948822/directory-wildcard-in-makefile-pattern-rule
 .SECONDEXPANSION:
 
-.build/%/plutus-core-kompiled/interpreter: src/%/plutus-core.k $(wildcard src/*.k) $$(wildcard src/$$*/*.k) $(dep_files)
+.build/%/plutus-core-kompiled/interpreter: src/%/plutus-core.k $(wildcard src/*.k) $$(wildcard src/$$*/*.k) $(k_bin)/krun
 	eval $$(opam config env) \
 	$(k_bin)/kompile --debug --verbose --directory .build/$*/ \
 					 --syntax-module PLUTUS-CORE-SYNTAX src/$*/plutus-core.k

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ and a `virtualenv` with `pytest` installed.
 
 For subsequent builds run `./build [options for pytest]`.
 
+To execute a Plutus program, run: `./build kplc run execution <pgm.plc> [arguments to bin/kplc]`.
+
+To translate to IELE, run: `./build kplc run translate <pgm.plc> [arguments to bin/kplc]`.
+
 To Do
 -----
 

--- a/README.md
+++ b/README.md
@@ -5,17 +5,15 @@ This repository will contains the K Framework implementation of the core
 language of the Plutus language ([a prototype of Plutus can be viewed
 here](https://github.com/input-output-hk/plutus-prototype)).
 
-Installing
-----------
+Usage
+-----
 
-To build Plutus, run: `make build-deps && make build-passing`.
+The `build` script is responsible for building and running tests.
+For the first build, run `./build deps [options for pytest]`.
+This will build all dependencies, including K, IELE and its dependencies,
+and a `virtualenv` with `pytest` installed.
 
-To run all tests, run: `make test-passing`.
-
-To run test with `pytest` directly, we require that some environment setup
-is done. If your shell is `bash`, `source .bin/activate`.
-`.bin/activate` does not currently support other shells. You can work around this
-for example, in `zsh` by running: `exec bash -c 'source .bin/activate ; exec zsh`
+For subsequent builds run `./build [options for pytest]`.
 
 To Do
 -----

--- a/bin/activate
+++ b/bin/activate
@@ -19,8 +19,8 @@ PATH="$release_dir/bin/:$PATH"
 export PATH
 
 export PLUTUS_PREFIX="$build_dir/local"
-export LD_LIBRARY_PATH="$build_dir/local/lib/:$LDPATH"
+export LD_LIBRARY_PATH="$PLUTUS_PREFIX/lib/:$LD_LIBRARY_PATH"
+export PKG_CONFIG_PATH="$PLUTUS_PREFIX/lib/pkgconfig/:$PKG_CONFIG_PATH"
 
 eval $(opam config env)
-
 . "$build_dir/virtualenv/bin/activate"

--- a/bin/kplc
+++ b/bin/kplc
@@ -1,78 +1,52 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python
 
-set -e      # Exit immediately if any command fails
-set -u      # Using undefined variables is an error. Exit immediately
+from __future__ import print_function
+from argparse import ArgumentParser, REMAINDER
+import os
+import subprocess
+import sys
 
-# Utilities
-# ---------
-
-die()      { echo -e "FATAL:" "$@" >&2 ; exit 1 ; }
-
-pretty_diff() {
-    git --no-pager diff --no-index "$@"
-}
-
-# Environment Setup
-# -----------------
-
-run_env() {
-    base_dir="$(cd $(dirname $0)/.. && pwd -P)"
-    build_dir="$base_dir/.build"
-}
+_base = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+def base(*args)     : return os.path.join(_base, *args)
+def bin(*args)      : return base('bin', *args)
+def build(*args)    : return base('.build', *args)
 
 # Runners
 # -------
 
-run_krun() {
-    local driver=$1   ; shift
-    local run_file=$1 ; shift
-    export K_OPTS=-Xss500m
-    krun --directory "$build_dir/$driver/" "$run_file" "$@"
-}
+def run_krun(driver, file, *args): 
+    os.environ['K_OPTS'] = '-Xss500m'
+    print('krun',  '--directory', build(driver), file, *args, file=sys.stderr)
+    os.execlp('krun',  'krun', '--directory', build(driver), file, *args)
 
-run_kprove() {
-    local driver="$1"     ; shift
-    local proof_file="$1" ; shift
-    local init_file="$1"  ; shift
-    [[ -f "$proof_file" ]] || die "$proof_file does not exist"
-    [[ -f "$init_file"  ]] || die "$init_file does not exist"
-    export K_OPTS=-Xmx2G
-    ( krun --directory $(build_dir)/$driver --z3-executable "$init_file" --prove "$proof_file" "$@" )
-}
-
-run_kdebug() {
-    local driver="$1"     ; shift
-    local debug_file="$1" ; shift
-    ( run_krun "$driver" "$debug_file" --debugger "$@" )
-}
+def run_kprove(driver, spec, init, *args):
+    os.stat(spec)
+    os.stat(init)
+    os.environ['K_OPTS'] = '-Xmx2G'
+    os.execlp('krun',  'krun', '--directory', build(driver), '--z3-executable', init, '--prove', spec, *args)
 
 # Main
 # ----
 
-run_env
+def main():
+    argparser = ArgumentParser(description='krun a Plutus Core program')
+    subparsers = argparser.add_subparsers(dest='subparser')
+    run = subparsers.add_parser('run', help='Run a Plutus Program using a particular kompiled definition')
+    run.add_argument('driver',  help='kompiled definition to use in `.build`')
+    run.add_argument('program', help='Plutus Core program')
+    run.add_argument('args',    nargs=REMAINDER, help='additional arguments to pass to `krun`')
 
-# main functionality
-run_command="$1" ; shift
-case "$run_command" in
+    prove = subparsers.add_parser('prove', help='Check a Plutus Program against a reachability specification')
+    prove.add_argument('driver' , help='kompiled definition to use in `.build`')
+    prove.add_argument('spec'   , help='reachability spec')
+    prove.add_argument('program', help='Plutus Core program')
+    prove.add_argument('args',    nargs=REMAINDER, help='additional arguments to pass to `krun`')
 
-    # Running
-    run)   run_krun   "$@" ;;
-    debug) run_kdebug "$@" ;;
-    prove) run_kprove "$@" ;;
+    args = argparser.parse_args()
+    if args.subparser == 'run':
+        run_krun(args.driver,            args.program, *args.args)
+    elif args.subparser == 'prove':
+        run_krun(args.driver, args.spec, args.program, *args.args)
 
-    *) echo "
-    usage: $0 [run|debug|prove] <driver> <file> <K args>*
-
-       # Running
-       # -------
-       $0 run   <driver> <pgm>          Run a single PLC program
-       $0 debug <driver> <pgm>          Run a single PLC program in the debugger
-       $0 prove <driver> <spec> <pgm>   Attempt to prove claim over PLC program
-
-       Note: <pgm> is a path to a file containing a PLC program.
-             <spec> is a K reachability claim file.
-             <driver> is one of [erc20|execution|translation|typing]
-
-       Note: This command is more for devs and CI servers.
-" ; exit ;;
-esac
+if __name__ == '__main__':
+    main()

--- a/build
+++ b/build
@@ -7,10 +7,12 @@ set -e
 
 clean=false
 deps=false
+runner=(pytest -n 4)
 while [[  $# -ne 0 ]]; do case "$1" in
-    clean) clean=true ;;
-     deps) deps=true  ;;
-        *) break      ;;
+    clean) clean=true          ;;
+     deps) deps=true           ;;
+     kplc) runner=( bin/kplc ) ;;
+        *) break               ;;
 esac; shift; done
 
             targets=( )
@@ -23,4 +25,4 @@ esac; shift; done
 ! $clean || rm -rf .build/
 source bin/activate
 make -j4 "${targets[@]}"
-exec pytest -n 4 "$@"
+exec "${runner[@]}" "$@"

--- a/build
+++ b/build
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Arguement parsing
+# =================
+
+clean=false
+deps=false
+while [[  $# -ne 0 ]]; do case "$1" in
+    clean) clean=true ;;
+     deps) deps=true  ;;
+        *) break      ;;
+esac; shift; done
+
+            targets=( )
+! $deps  || targets+=( deps )
+            targets+=( execution translation translate-to-iele )
+
+# Main
+# ====
+
+! $clean || rm -rf .build/
+source bin/activate
+make -j4 "${targets[@]}"
+exec pytest -n 4 "$@"


### PR DESCRIPTION
We also conver `kplc` to python for future maintainability.

I had also wanted to have `kplc` accept arguments to pass to the execution driver, but was not sure about how the interface would handle other options for passing to `krun`.