### PR TITLE
Adds the factorial test

### DIFF
--- a/t/factorial.plc
+++ b/t/factorial.plc
@@ -1,0 +1,415 @@
+(program 0.1.0
+  [
+    {
+      (abs
+        s
+        (size)
+        (lam
+          i
+          [(con integer) s]
+          [
+            [
+              {
+                (abs
+                  s
+                  (size)
+                  (lam
+                    ss
+                    [(con size) s]
+                    [
+                      [
+                        {
+                          {
+                            (abs
+                              a
+                              (type)
+                              (abs
+                                r
+                                (type)
+                                (lam
+                                  f
+                                  (fun r (fun a r))
+                                  [
+                                    {
+                                      {
+                                        (abs
+                                          a
+                                          (type)
+                                          (abs
+                                            b
+                                            (type)
+                                            (lam
+                                              f
+                                              (fun (fun a b) (fun a b))
+                                              [
+                                                {
+                                                  (abs
+                                                    a
+                                                    (type)
+                                                    (lam
+                                                      s
+                                                      [(lam a (type) (fix self (fun self a))) a]
+                                                      [ (unwrap s) s ]
+                                                    )
+                                                  )
+                                                  (fun a b)
+                                                }
+                                                (wrap
+                                                  self
+                                                  [(lam a (type) (fun self a)) (fun a b)]
+                                                  (lam
+                                                    s
+                                                    [(lam a (type) (fix self (fun self a))) (fun a b)]
+                                                    (lam
+                                                      x
+                                                      a
+                                                      [
+                                                        [
+                                                          f
+                                                          [
+                                                            {
+                                                              (abs
+                                                                a
+                                                                (type)
+                                                                (lam
+                                                                  s
+                                                                  [(lam a (type) (fix self (fun self a))) a]
+                                                                  [
+                                                                    (unwrap s) s
+                                                                  ]
+                                                                )
+                                                              )
+                                                              (fun a b)
+                                                            }
+                                                            s
+                                                          ]
+                                                        ]
+                                                        x
+                                                      ]
+                                                    )
+                                                  )
+                                                )
+                                              ]
+                                            )
+                                          )
+                                        )
+                                        r
+                                      }
+                                      (fun [(lam a (type) (fix list (all r (type) (fun r (fun (fun a (fun list r)) r))))) a] r)
+                                    }
+                                    (lam
+                                      rec
+                                      (fun r (fun [(lam a (type) (fix list (all r (type) (fun r (fun (fun a (fun list r)) r))))) a] r))
+                                      (lam
+                                        z
+                                        r
+                                        (lam
+                                          xs
+                                          [(lam a (type) (fix list (all r (type) (fun r (fun (fun a (fun list r)) r))))) a]
+                                          [
+                                            [
+                                              { (unwrap xs) r } z
+                                            ]
+                                            (lam
+                                              x
+                                              a
+                                              (lam
+                                                xs'
+                                                [(lam a (type) (fix list (all r (type) (fun r (fun (fun a (fun list r)) r))))) a]
+                                                [ [ rec [ [ f z ] x ] ] xs' ]
+                                              )
+                                            )
+                                          ]
+                                        )
+                                      )
+                                    )
+                                  ]
+                                )
+                              )
+                            )
+                            [(con integer) s]
+                          }
+                          [(con integer) s]
+                        }
+                        { (builtin multiplyInteger) s }
+                      ]
+                      [
+                        [ { { (builtin resizeInteger) (con 1) } s } ss ]
+                        (con 1 ! 1)
+                      ]
+                    ]
+                  )
+                )
+                s
+              }
+              [ { (builtin sizeOfInteger) s } i ]
+            ]
+            [
+              [
+                {
+                  (abs
+                    s
+                    (size)
+                    (lam
+                      n
+                      [(con integer) s]
+                      (lam
+                        m
+                        [(con integer) s]
+                        [
+                          [
+                            {
+                              {
+                                (abs
+                                  a
+                                  (type)
+                                  (abs
+                                    b
+                                    (type)
+                                    (lam
+                                      f
+                                      (fun (fun a b) (fun a b))
+                                      [
+                                        {
+                                          (abs
+                                            a
+                                            (type)
+                                            (lam
+                                              s
+                                              [(lam a (type) (fix self (fun self a))) a]
+                                              [ (unwrap s) s ]
+                                            )
+                                          )
+                                          (fun a b)
+                                        }
+                                        (wrap
+                                          self
+                                          [(lam a (type) (fun self a)) (fun a b)]
+                                          (lam
+                                            s
+                                            [(lam a (type) (fix self (fun self a))) (fun a b)]
+                                            (lam
+                                              x
+                                              a
+                                              [
+                                                [
+                                                  f
+                                                  [
+                                                    {
+                                                      (abs
+                                                        a
+                                                        (type)
+                                                        (lam
+                                                          s
+                                                          [(lam a (type) (fix self (fun self a))) a]
+                                                          [ (unwrap s) s ]
+                                                        )
+                                                      )
+                                                      (fun a b)
+                                                    }
+                                                    s
+                                                  ]
+                                                ]
+                                                x
+                                              ]
+                                            )
+                                          )
+                                        )
+                                      ]
+                                    )
+                                  )
+                                )
+                                [(con integer) s]
+                              }
+                              [(lam a (type) (fix list (all r (type) (fun r (fun (fun a (fun list r)) r))))) [(con integer) s]]
+                            }
+                            (lam
+                              rec
+                              (fun [(con integer) s] [(lam a (type) (fix list (all r (type) (fun r (fun (fun a (fun list r)) r))))) [(con integer) s]])
+                              (lam
+                                n'
+                                [(con integer) s]
+                                [
+                                  [
+                                    [
+                                      {
+                                        (abs
+                                          a
+                                          (type)
+                                          (lam
+                                            b
+                                            (all a (type) (fun a (fun a a)))
+                                            (lam
+                                              x
+                                              (fun (all a (type) (fun a a)) a)
+                                              (lam
+                                                y
+                                                (fun (all a (type) (fun a a)) a)
+                                                [
+                                                  [
+                                                    [
+                                                      {
+                                                        b
+                                                        (fun (all a (type) (fun a a)) a)
+                                                      }
+                                                      x
+                                                    ]
+                                                    y
+                                                  ]
+                                                  (abs a (type) (lam x a x))
+                                                ]
+                                              )
+                                            )
+                                          )
+                                        )
+                                        [(lam a (type) (fix list (all r (type) (fun r (fun (fun a (fun list r)) r))))) [(con integer) s]]
+                                      }
+                                      [
+                                        [
+                                          { (builtin greaterThanInteger) s } n'
+                                        ]
+                                        m
+                                      ]
+                                    ]
+                                    (lam
+                                      u
+                                      (all a (type) (fun a a))
+                                      {
+                                        (abs
+                                          a
+                                          (type)
+                                          (wrap
+                                            list
+                                            [(lam a (type) (all r (type) (fun r (fun (fun a (fun list r)) r)))) a]
+                                            (abs
+                                              r
+                                              (type)
+                                              (lam
+                                                z
+                                                r
+                                                (lam
+                                                  f
+                                                  (fun a (fun [(lam a (type) (fix list (all r (type) (fun r (fun (fun a (fun list r)) r))))) a] r))
+                                                  z
+                                                )
+                                              )
+                                            )
+                                          )
+                                        )
+                                        [(con integer) s]
+                                      }
+                                    )
+                                  ]
+                                  (lam
+                                    u
+                                    (all a (type) (fun a a))
+                                    [
+                                      [
+                                        {
+                                          (abs
+                                            a
+                                            (type)
+                                            (lam
+                                              x
+                                              a
+                                              (lam
+                                                xs
+                                                [(lam a (type) (fix list (all r (type) (fun r (fun (fun a (fun list r)) r))))) a]
+                                                (wrap
+                                                  list
+                                                  [(lam a (type) (all r (type) (fun r (fun (fun a (fun list r)) r)))) a]
+                                                  (abs
+                                                    r
+                                                    (type)
+                                                    (lam
+                                                      z
+                                                      r
+                                                      (lam
+                                                        f
+                                                        (fun a (fun [(lam a (type) (fix list (all r (type) (fun r (fun (fun a (fun list r)) r))))) a] r))
+                                                        [ [ f x ] xs ]
+                                                      )
+                                                    )
+                                                  )
+                                                )
+                                              )
+                                            )
+                                          )
+                                          [(con integer) s]
+                                        }
+                                        n'
+                                      ]
+                                      [
+                                        rec
+                                        [
+                                          {
+                                            (abs
+                                              s
+                                              (size)
+                                              (lam
+                                                i
+                                                [(con integer) s]
+                                                [
+                                                  [
+                                                    { (builtin addInteger) s } i
+                                                  ]
+                                                  [
+                                                    [
+                                                      {
+                                                        {
+                                                          (builtin resizeInteger
+                                                          )
+                                                          (con 1)
+                                                        }
+                                                        s
+                                                      }
+                                                      [
+                                                        {
+                                                          (builtin sizeOfInteger
+                                                          )
+                                                          s
+                                                        }
+                                                        i
+                                                      ]
+                                                    ]
+                                                    (con 1 ! 1)
+                                                  ]
+                                                ]
+                                              )
+                                            )
+                                            s
+                                          }
+                                          n'
+                                        ]
+                                      ]
+                                    ]
+                                  )
+                                ]
+                              )
+                            )
+                          ]
+                          n
+                        ]
+                      )
+                    )
+                  )
+                  s
+                }
+                [
+                  [
+                    { { (builtin resizeInteger) (con 1) } s }
+                    [ { (builtin sizeOfInteger) s } i ]
+                  ]
+                  (con 1 ! 1)
+                ]
+              ]
+              i
+            ]
+          ]
+        )
+      )
+      (con 3)
+    }
+    (con 3 ! 3)
+  ]
+)

--- a/t/factorial.plc.expected
+++ b/t/factorial.plc.expected
@@ -1,0 +1,8 @@
+<generatedTop>
+  <k>
+    ( con 3 ! 6 )
+  </k>
+  <env>
+    .Map
+  </env>
+</generatedTop>


### PR DESCRIPTION
This adds the following test: `product (enumFromTo 1 3) == 6`.

It won't pass, because the `sizeOfInteger` built-in is used which is a recent addition. In short, we added `sizeOfInteger : all s. integer s -> size s`, because this allows to remove some annoying boileplate. tl;dr is [here](https://github.com/input-output-hk/plutus/blob/12a87df41324b5ca2ae1b657fc88259cf1fffbbb/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs#L60).